### PR TITLE
[BREAKING] Rename overvoltage to battery_overvoltage sensor

### DIFF
--- a/components/jnge_mppt_controller/jnge_mppt_controller.cpp
+++ b/components/jnge_mppt_controller/jnge_mppt_controller.cpp
@@ -334,13 +334,13 @@ void JngeMpptController::on_configuration_data_(const std::vector<uint8_t> &data
   // Address Content                          Length    Coeff.  Unit     Example value
   //
   // 0x1024: Overvoltage                      2 bytes   0.1     V
-  this->publish_state_(this->overvoltage_sensor_, (float) jnge_get_16bit(0) * 0.1f);
+  this->publish_state_(this->battery_overvoltage_sensor_, (float) jnge_get_16bit(0) * 0.1f);
 
   // 0x1025: Charging limit voltage           2 bytes   0.1     V
   this->publish_state_(this->charging_limit_voltage_sensor_, (float) jnge_get_16bit(2) * 0.1f);
 
   // 0x1026: Overvoltage recovery             2 bytes   0.1     V
-  this->publish_state_(this->overvoltage_recovery_sensor_, (float) jnge_get_16bit(4) * 0.1f);
+  this->publish_state_(this->battery_overvoltage_recovery_sensor_, (float) jnge_get_16bit(4) * 0.1f);
 
   // 0x1027: Equalizing charging voltage      2 bytes   0.1     V
   this->publish_state_(this->equalizing_charging_voltage_sensor_, (float) jnge_get_16bit(6) * 0.1f);
@@ -535,9 +535,9 @@ void JngeMpptController::dump_config() {  // NOLINT(google-readability-function-
   LOG_SENSOR("", "Battery Temperature Compensation Voltage Point",
              this->battery_temperature_compensation_voltage_point_sensor_);
 
-  LOG_SENSOR("", "Overvoltage", this->overvoltage_sensor_);
+  LOG_SENSOR("", "Battery Overvoltage", this->battery_overvoltage_sensor_);
   LOG_SENSOR("", "Charging Voltage Limit", this->charging_limit_voltage_sensor_);
-  LOG_SENSOR("", "Overvoltage Recovery", this->overvoltage_recovery_sensor_);
+  LOG_SENSOR("", "Battery Overvoltage Recovery", this->battery_overvoltage_recovery_sensor_);
   LOG_SENSOR("", "Equalizing Charging Voltage", this->equalizing_charging_voltage_sensor_);
   LOG_SENSOR("", "Boost Charging Voltage", this->boost_charging_voltage_sensor_);
   LOG_SENSOR("", "Boost Charging Return Voltage", this->boost_charging_return_voltage_sensor_);

--- a/components/jnge_mppt_controller/jnge_mppt_controller.h
+++ b/components/jnge_mppt_controller/jnge_mppt_controller.h
@@ -90,12 +90,14 @@ class JngeMpptController : public PollingComponent, public jnge_modbus::JngeModb
   }
 
   // configuration
-  void set_overvoltage_sensor(sensor::Sensor *overvoltage_sensor) { overvoltage_sensor_ = overvoltage_sensor; }
+  void set_battery_overvoltage_sensor(sensor::Sensor *battery_overvoltage_sensor) {
+    battery_overvoltage_sensor_ = battery_overvoltage_sensor;
+  }
   void set_charging_limit_voltage_sensor(sensor::Sensor *charging_limit_voltage_sensor) {
     charging_limit_voltage_sensor_ = charging_limit_voltage_sensor;
   }
-  void set_overvoltage_recovery_sensor(sensor::Sensor *overvoltage_recovery_sensor) {
-    overvoltage_recovery_sensor_ = overvoltage_recovery_sensor;
+  void set_battery_overvoltage_recovery_sensor(sensor::Sensor *battery_overvoltage_recovery_sensor) {
+    battery_overvoltage_recovery_sensor_ = battery_overvoltage_recovery_sensor;
   }
   void set_equalizing_charging_voltage_sensor(sensor::Sensor *equalizing_charging_voltage_sensor) {
     equalizing_charging_voltage_sensor_ = equalizing_charging_voltage_sensor;
@@ -204,9 +206,9 @@ class JngeMpptController : public PollingComponent, public jnge_modbus::JngeModb
   sensor::Sensor *battery_strings_sensor_;
 
   // configuration
-  sensor::Sensor *overvoltage_sensor_;
+  sensor::Sensor *battery_overvoltage_sensor_;
   sensor::Sensor *charging_limit_voltage_sensor_;
-  sensor::Sensor *overvoltage_recovery_sensor_;
+  sensor::Sensor *battery_overvoltage_recovery_sensor_;
   sensor::Sensor *equalizing_charging_voltage_sensor_;
   sensor::Sensor *boost_charging_voltage_sensor_;
   sensor::Sensor *boost_charging_return_voltage_sensor_;

--- a/components/jnge_mppt_controller/sensor.py
+++ b/components/jnge_mppt_controller/sensor.py
@@ -52,9 +52,9 @@ CONF_BATTERY_TEMPERATURE_COMPENSATION_VOLTAGE_POINT = (
     "battery_temperature_compensation_voltage_point"
 )
 
-CONF_OVERVOLTAGE = "overvoltage"
+CONF_BATTERY_OVERVOLTAGE = "battery_overvoltage"
 CONF_CHARGING_LIMIT_VOLTAGE = "charging_limit_voltage"
-CONF_OVERVOLTAGE_RECOVERY = "overvoltage_recovery"
+CONF_BATTERY_OVERVOLTAGE_RECOVERY = "battery_overvoltage_recovery"
 CONF_EQUALIZING_CHARGING_VOLTAGE = "equalizing_charging_voltage"
 CONF_BOOST_CHARGING_VOLTAGE = "boost_charging_voltage"
 CONF_BOOST_CHARGING_RETURN_VOLTAGE = "boost_charging_return_voltage"
@@ -63,7 +63,6 @@ CONF_OVER_DISCHARGE_VOLTAGE = "over_discharge_voltage"
 CONF_OVER_DISCHARGE_RECOVERY_VOLTAGE = "over_discharge_recovery_voltage"
 CONF_BATTERY_UNDERVOLTAGE = "battery_undervoltage"
 CONF_EQUALIZATION_CHARGING_TIME = "equalization_charging_time"
-CONF_BATTERY_UNDERVOLTAGE = "battery_undervoltage"
 CONF_IMPROVE_CHARGING_TIME = "improve_charging_time"
 CONF_TEMPERATURE_COMPENSATION_COEFFICIENT = "temperature_compensation_coefficient"
 CONF_DEVICE_ADDRESS = "device_address"
@@ -98,9 +97,9 @@ SENSORS = [
     CONF_CONTROLLER_CURRENT_LEVEL,
     CONF_BATTERY_TEMPERATURE_COMPENSATION_VOLTAGE_POINT,
     # configuration
-    CONF_OVERVOLTAGE,
+    CONF_BATTERY_OVERVOLTAGE,
     CONF_CHARGING_LIMIT_VOLTAGE,
-    CONF_OVERVOLTAGE_RECOVERY,
+    CONF_BATTERY_OVERVOLTAGE_RECOVERY,
     CONF_EQUALIZING_CHARGING_VOLTAGE,
     CONF_BOOST_CHARGING_VOLTAGE,
     CONF_BOOST_CHARGING_RETURN_VOLTAGE,
@@ -263,13 +262,13 @@ CONFIG_SCHEMA = cv.Schema(
             STATE_CLASS_MEASUREMENT,
         ),
         # Configuration
-        cv.Optional(CONF_OVERVOLTAGE): sensor.sensor_schema(
+        cv.Optional(CONF_BATTERY_OVERVOLTAGE): sensor.sensor_schema(
             UNIT_VOLT, ICON_EMPTY, 1, DEVICE_CLASS_VOLTAGE, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional(CONF_CHARGING_LIMIT_VOLTAGE): sensor.sensor_schema(
             UNIT_VOLT, ICON_EMPTY, 1, DEVICE_CLASS_VOLTAGE, STATE_CLASS_MEASUREMENT
         ),
-        cv.Optional(CONF_OVERVOLTAGE_RECOVERY): sensor.sensor_schema(
+        cv.Optional(CONF_BATTERY_OVERVOLTAGE_RECOVERY): sensor.sensor_schema(
             UNIT_VOLT, ICON_EMPTY, 1, DEVICE_CLASS_VOLTAGE, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional(CONF_EQUALIZING_CHARGING_VOLTAGE): sensor.sensor_schema(

--- a/esp32-example-jnge-mppt-controller.yaml
+++ b/esp32-example-jnge-mppt-controller.yaml
@@ -94,12 +94,12 @@ sensor:
       name: "${status} battery temperature compensation voltage point"
 
     # config
-    overvoltage:
-      name: "${config} overvoltage"
+    battery_overvoltage:
+      name: "${config} battery overvoltage"
     charging_limit_voltage:
       name: "${config} charging limit voltage"
-    overvoltage_recovery:
-      name: "${config} overvoltage recovery"
+    battery_overvoltage_recovery:
+      name: "${config} battery overvoltage recovery"
     equalizing_charging_voltage:
       name: "${config} equalizing charging voltage"
     boost_charging_voltage:

--- a/esp8266-example-jnge-mppt-controller.yaml
+++ b/esp8266-example-jnge-mppt-controller.yaml
@@ -96,12 +96,12 @@ sensor:
       name: "${status} battery temperature compensation voltage point"
 
     # config
-    overvoltage:
-      name: "${config} overvoltage"
+    battery_overvoltage:
+      name: "${config} battery overvoltage"
     charging_limit_voltage:
       name: "${config} charging limit voltage"
-    overvoltage_recovery:
-      name: "${config} overvoltage recovery"
+    battery_overvoltage_recovery:
+      name: "${config} battery overvoltage recovery"
     equalizing_charging_voltage:
       name: "${config} equalizing charging voltage"
     boost_charging_voltage:

--- a/jnge_mppt_controller.md
+++ b/jnge_mppt_controller.md
@@ -190,12 +190,12 @@ sensor:
       name: "${status} battery temperature compensation voltage point"
 
     # config
-    overvoltage:
-      name: "${config} overvoltage"
+    battery_overvoltage:
+      name: "${config} battery overvoltage"
     charging_limit_voltage:
       name: "${config} charging limit voltage"
-    overvoltage_recovery:
-      name: "${config} overvoltage recovery"
+    battery_overvoltage_recovery:
+      name: "${config} battery overvoltage recovery"
     equalizing_charging_voltage:
       name: "${config} equalizing charging voltage"
     boost_charging_voltage:


### PR DESCRIPTION
This is a breaking change! Please update your configuration: Rename the `overvoltage` sensor to `battery_overvoltage`.