### PR TITLE
Move minimum ESPHome version requirement into validator

### DIFF
--- a/components/jnge_g_series/__init__.py
+++ b/components/jnge_g_series/__init__.py
@@ -34,7 +34,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(cv.polling_component_schema("5s"))
-    .extend(jnge_modbus.jnge_modbus_device_schema(0x06))
+    .extend(jnge_modbus.jnge_modbus_device_schema(0x06)),
 )
 
 

--- a/components/jnge_g_series/__init__.py
+++ b/components/jnge_g_series/__init__.py
@@ -26,7 +26,8 @@ JNGE_G_SERIES_COMPONENT_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2024, 12, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(JngeGSeries),

--- a/components/jnge_mppt_controller/__init__.py
+++ b/components/jnge_mppt_controller/__init__.py
@@ -45,7 +45,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(cv.polling_component_schema("5s"))
-    .extend(jnge_modbus.jnge_modbus_device_schema(0x06))
+    .extend(jnge_modbus.jnge_modbus_device_schema(0x06)),
 )
 
 

--- a/components/jnge_mppt_controller/__init__.py
+++ b/components/jnge_mppt_controller/__init__.py
@@ -33,7 +33,8 @@ JNGE_MPPT_CONTROLLER_COMPONENT_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2025, 11, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(JngeMpptController),

--- a/components/jnge_wind_solar_controller/__init__.py
+++ b/components/jnge_wind_solar_controller/__init__.py
@@ -33,7 +33,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(cv.polling_component_schema("5s"))
-    .extend(jnge_modbus.jnge_modbus_device_schema(0x06))
+    .extend(jnge_modbus.jnge_modbus_device_schema(0x06)),
 )
 
 

--- a/components/jnge_wind_solar_controller/__init__.py
+++ b/components/jnge_wind_solar_controller/__init__.py
@@ -24,7 +24,8 @@ JNGE_WIND_SOLAR_CONTROLLER_COMPONENT_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2025, 11, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(JngeWindSolarController),

--- a/esp32-example-jnge-g-series.yaml
+++ b/esp32-example-jnge-g-series.yaml
@@ -10,7 +10,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.11.0
   project:
     name: "syssi.esphome-jnge-mppt-controller"
     version: 1.5.0

--- a/esp32-example-jnge-mppt-controller.yaml
+++ b/esp32-example-jnge-mppt-controller.yaml
@@ -13,7 +13,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.11.0
   project:
     name: "syssi.esphome-jnge-mppt-controller"
     version: 1.5.0

--- a/esp32-example-jnge-wind-solar-controller.yaml
+++ b/esp32-example-jnge-wind-solar-controller.yaml
@@ -10,7 +10,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.11.0
   project:
     name: "syssi.esphome-jnge-mppt-controller"
     version: 1.5.0

--- a/esp8266-example-jnge-g-series.yaml
+++ b/esp8266-example-jnge-g-series.yaml
@@ -10,7 +10,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.11.0
   project:
     name: "syssi.esphome-jnge-mppt-controller"
     version: 1.5.0

--- a/esp8266-example-jnge-mppt-controller.yaml
+++ b/esp8266-example-jnge-mppt-controller.yaml
@@ -10,7 +10,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.11.0
   project:
     name: "syssi.esphome-jnge-mppt-controller"
     version: 1.5.0

--- a/esp8266-example-jnge-wind-solar-controller.yaml
+++ b/esp8266-example-jnge-wind-solar-controller.yaml
@@ -10,7 +10,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.11.0
   project:
     name: "syssi.esphome-jnge-mppt-controller"
     version: 1.5.0

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -6,7 +6,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.6.0
 
 esp32:
   board: esp32-c6-devkitc-1

--- a/tests/esp8266-fake-g-series.yaml
+++ b/tests/esp8266-fake-g-series.yaml
@@ -5,7 +5,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2025.11.0
 
 esp8266:
   board: d1_mini


### PR DESCRIPTION
Removes min_version from all YAML configurations and enforces the version constraint via cv.require_esphome_version() in the component validator instead.