### PR TITLE
Remove redundant .extend(cv.COMPONENT_SCHEMA) from switch and button schemas

### DIFF
--- a/components/jnge_mppt_controller/switch/__init__.py
+++ b/components/jnge_mppt_controller/switch/__init__.py
@@ -35,15 +35,15 @@ CONFIG_SCHEMA = JNGE_MPPT_CONTROLLER_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_BUZZER): switch.switch_schema(
             JngeSwitch, icon=ICON_BUZZER, entity_category=ENTITY_CATEGORY_CONFIG
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_STREET_LIGHT_MODE): switch.switch_schema(
             JngeSwitch,
             icon=ICON_STREET_LIGHT_MODE,
             entity_category=ENTITY_CATEGORY_CONFIG,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_CHARGING): switch.switch_schema(
             JngeSwitch, icon=ICON_CHARGING
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_LOAD): switch.switch_schema(JngeSwitch, icon=ICON_LOAD).extend(
             cv.COMPONENT_SCHEMA
         ),

--- a/components/jnge_wind_solar_controller/switch/__init__.py
+++ b/components/jnge_wind_solar_controller/switch/__init__.py
@@ -34,10 +34,10 @@ CONFIG_SCHEMA = JNGE_WIND_SOLAR_CONTROLLER_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_STREET_LIGHT_MODE): switch.switch_schema(
             JngeSwitch, icon=ICON_STREET_LIGHT_MODE
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_CHARGING): switch.switch_schema(
             JngeSwitch, icon=ICON_CHARGING
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_LOAD): switch.switch_schema(JngeSwitch, icon=ICON_LOAD).extend(
             cv.COMPONENT_SCHEMA
         ),


### PR DESCRIPTION
## Summary
- Remove `.extend(cv.COMPONENT_SCHEMA)` from all `switch.switch_schema()` and `button.button_schema()` calls
- `switch_schema()` and `button_schema()` include the component schema internally since ESPHome ~2023 — the explicit `.extend()` is redundant