### PR TITLE
Use new_* API instead of deprecated register_* functions

### DIFF
--- a/components/jnge_mppt_controller/binary_sensor.py
+++ b/components/jnge_mppt_controller/binary_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, ENTITY_CATEGORY_DIAGNOSTIC
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import CONF_JNGE_MPPT_CONTROLLER_ID, JNGE_MPPT_CONTROLLER_COMPONENT_SCHEMA
 from .const import CONF_CHARGING, CONF_LOAD
@@ -49,6 +49,5 @@ async def to_code(config):
     for key in BINARY_SENSORS:
         if key in config:
             conf = config[key]
-            sens = cg.new_Pvariable(conf[CONF_ID])
-            await binary_sensor.register_binary_sensor(sens, conf)
+            sens = await binary_sensor.new_binary_sensor(conf)
             cg.add(getattr(hub, f"set_{key}_binary_sensor")(sens))

--- a/components/jnge_mppt_controller/number/__init__.py
+++ b/components/jnge_mppt_controller/number/__init__.py
@@ -2,7 +2,6 @@ import esphome.codegen as cg
 from esphome.components import number
 import esphome.config_validation as cv
 from esphome.const import (
-    CONF_ID,
     CONF_MAX_VALUE,
     CONF_MIN_VALUE,
     CONF_MODE,

--- a/components/jnge_mppt_controller/number/__init__.py
+++ b/components/jnge_mppt_controller/number/__init__.py
@@ -232,15 +232,13 @@ async def to_code(config):
     for key, address in NUMBERS.items():
         if key in config:
             conf = config[key]
-            var = cg.new_Pvariable(conf[CONF_ID])
-            await cg.register_component(var, conf)
-            await number.register_number(
-                var,
+            var = await number.new_number(
                 conf,
                 min_value=conf[CONF_MIN_VALUE],
                 max_value=conf[CONF_MAX_VALUE],
                 step=conf[CONF_STEP],
             )
+            await cg.register_component(var, conf)
             cg.add(getattr(hub, f"set_{key}_number")(var))
             cg.add(var.set_parent(hub))
             cg.add(var.set_holding_register(address))

--- a/components/jnge_mppt_controller/select/__init__.py
+++ b/components/jnge_mppt_controller/select/__init__.py
@@ -2,7 +2,6 @@ import esphome.codegen as cg
 from esphome.components import select
 from esphome.components.select import select_schema
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
 
 from .. import (
     CONF_JNGE_MPPT_CONTROLLER_ID,
@@ -62,9 +61,8 @@ async def to_code(config):
         if key in config:
             conf = config[key]
             options_map = conf[CONF_OPTIONSMAP]
-            var = cg.new_Pvariable(conf[CONF_ID])
+            var = await select.new_select(conf, options=list(options_map.values()))
             await cg.register_component(var, conf)
-            await select.register_select(var, conf, options=list(options_map.values()))
             cg.add(var.set_select_mappings(list(options_map.keys())))
 
             cg.add(getattr(hub, f"set_{key}_select")(var))

--- a/components/jnge_mppt_controller/switch/__init__.py
+++ b/components/jnge_mppt_controller/switch/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import switch
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, ENTITY_CATEGORY_CONFIG
+from esphome.const import ENTITY_CATEGORY_CONFIG
 
 from .. import (
     CONF_JNGE_MPPT_CONTROLLER_ID,
@@ -56,9 +56,8 @@ async def to_code(config):
     for key, address in SWITCHES.items():
         if key in config:
             conf = config[key]
-            var = cg.new_Pvariable(conf[CONF_ID])
+            var = await switch.new_switch(conf)
             await cg.register_component(var, conf)
-            await switch.register_switch(var, conf)
             cg.add(getattr(hub, f"set_{key}_switch")(var))
             cg.add(var.set_parent(hub))
             cg.add(var.set_holding_register(address))

--- a/components/jnge_wind_solar_controller/binary_sensor.py
+++ b/components/jnge_wind_solar_controller/binary_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, ENTITY_CATEGORY_DIAGNOSTIC
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import JNGE_WIND_SOLAR_CONTROLLER_COMPONENT_SCHEMA
 from .const import CONF_CHARGING, CONF_LOAD
@@ -45,6 +45,5 @@ async def to_code(config):
     for key in BINARY_SENSORS:
         if key in config:
             conf = config[key]
-            sens = cg.new_Pvariable(conf[CONF_ID])
-            await binary_sensor.register_binary_sensor(sens, conf)
+            sens = await binary_sensor.new_binary_sensor(conf)
             cg.add(getattr(hub, f"set_{key}_binary_sensor")(sens))

--- a/components/jnge_wind_solar_controller/switch/__init__.py
+++ b/components/jnge_wind_solar_controller/switch/__init__.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import switch
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
 
 from .. import (
     JNGE_WIND_SOLAR_CONTROLLER_COMPONENT_SCHEMA,
@@ -52,9 +51,8 @@ async def to_code(config):
     for key, address in SWITCHES.items():
         if key in config:
             conf = config[key]
-            var = cg.new_Pvariable(conf[CONF_ID])
+            var = await switch.new_switch(conf)
             await cg.register_component(var, conf)
-            await switch.register_switch(var, conf)
             cg.add(getattr(hub, f"set_{key}_switch")(var))
             cg.add(var.set_parent(hub))
             cg.add(var.set_holding_register(address))


### PR DESCRIPTION
Replace deprecated `register_binary_sensor`/`register_switch`/`register_button`/`register_number`/`register_select` calls with the modern `new_*` API. The `new_*` functions internally call `cg.new_Pvariable()` + `register_*()`, reducing boilerplate. `register_component()` is kept separately for Component subclasses.