### PR TITLE
Fix bitmask sensor

### DIFF
--- a/components/jnge_mppt_controller/sensor.py
+++ b/components/jnge_mppt_controller/sensor.py
@@ -272,7 +272,7 @@ CONFIG_SCHEMA = JNGE_MPPT_CONTROLLER_COMPONENT_SCHEMA.extend(
             unit_of_measurement=UNIT_EMPTY,
             icon=ICON_ERROR_BITMASK,
             accuracy_decimals=0,
-            device_class=None,
+            device_class=DEVICE_CLASS_EMPTY,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_CONTROLLER_VOLTAGE_LEVEL): sensor.sensor_schema(

--- a/components/jnge_wind_solar_controller/sensor.py
+++ b/components/jnge_wind_solar_controller/sensor.py
@@ -186,7 +186,7 @@ CONFIG_SCHEMA = JNGE_WIND_SOLAR_CONTROLLER_COMPONENT_SCHEMA.extend(
             unit_of_measurement=UNIT_EMPTY,
             icon=ICON_ERROR_BITMASK,
             accuracy_decimals=0,
-            device_class=None,
+            device_class=DEVICE_CLASS_EMPTY,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }


### PR DESCRIPTION
`device_class=None` is not a valid value in ESPHome's sensor schema and causes a validation error:

```
string value is None.
Error: Process completed with exit code 2.
```

Replace with `DEVICE_CLASS_EMPTY` which is the correct constant for sensors without a device class.