### PR TITLE
Use STATE_CLASS_TOTAL_INCREASING for discharge_times sensor

### DIFF
--- a/components/jnge_mppt_controller/sensor.py
+++ b/components/jnge_mppt_controller/sensor.py
@@ -241,7 +241,7 @@ CONFIG_SCHEMA = JNGE_MPPT_CONTROLLER_COMPONENT_SCHEMA.extend(
             icon=ICON_DISCHARGE_TIMES,
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_TOTAL_CHARGING_ENERGY): sensor.sensor_schema(


### PR DESCRIPTION
## Summary

- `discharge_times` is a cumulative, monotonically increasing counter and should use `STATE_CLASS_TOTAL_INCREASING` instead of `STATE_CLASS_MEASUREMENT`