### PR TITLE
Fix text_sensor_schema positional arg and add diagnostic entity category

### DIFF
--- a/components/jnge_mppt_controller/text_sensor.py
+++ b/components/jnge_mppt_controller/text_sensor.py
@@ -26,17 +26,14 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = JNGE_MPPT_CONTROLLER_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_OPERATION_MODE): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor,
             icon=ICON_OPERATION_MODE,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_ERRORS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor,
             icon=ICON_ERRORS,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_BATTERY_TYPE): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor,
             icon=ICON_BATTERY_TYPE,
             entity_category=ENTITY_CATEGORY_CONFIG,
         ),

--- a/components/jnge_wind_solar_controller/text_sensor.py
+++ b/components/jnge_wind_solar_controller/text_sensor.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import JNGE_WIND_SOLAR_CONTROLLER_COMPONENT_SCHEMA
 
@@ -25,13 +26,14 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = JNGE_WIND_SOLAR_CONTROLLER_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_OPERATION_MODE): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_OPERATION_MODE
+            icon=ICON_OPERATION_MODE
         ),
         cv.Optional(CONF_ERRORS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_ERRORS
+            icon=ICON_ERRORS,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_BATTERY_TYPE): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_BATTERY_TYPE
+            icon=ICON_BATTERY_TYPE
         ),
     }
 )


### PR DESCRIPTION
## Summary

- Remove positional `text_sensor.TextSensor` argument from `text_sensor_schema(...)` calls in `jnge_mppt_controller` (T1)
- Add `entity_category=ENTITY_CATEGORY_DIAGNOSTIC` to `errors` sensor in `jnge_wind_solar_controller` (T2)

Follows the pattern established in `esphome-tianpower-bms`.