### PR TITLE
Remove redundant name substitution prefix from entity names

### DIFF
--- a/esp32-example-jnge-g-series.yaml
+++ b/esp32-example-jnge-g-series.yaml
@@ -1,7 +1,7 @@
 substitutions:
   name: jn-g
-  status: "${name} status"
-  config: "${name} config"
+  status: "status"
+  config: "config"
   device_description: "Monitor a JN-G series inverter via RS485 (Modbus)"
   external_components_source: github://syssi/esphome-jnge-mppt-controller@main
   tx_pin: GPIO16

--- a/esp32-example-jnge-g-series.yaml
+++ b/esp32-example-jnge-g-series.yaml
@@ -9,6 +9,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-jnge-mppt-controller"

--- a/esp32-example-jnge-mppt-controller.yaml
+++ b/esp32-example-jnge-mppt-controller.yaml
@@ -1,7 +1,7 @@
 substitutions:
   name: jn-mppt
-  status: "${name} status"
-  config: "${name} config"
+  status: "status"
+  config: "config"
   device_description: "Monitor and control a JN-MPPT Solar Charge Controller via RS485 (Modbus)"
   external_components_source: github://syssi/esphome-jnge-mppt-controller@main
   tx_pin: GPIO16

--- a/esp32-example-jnge-mppt-controller.yaml
+++ b/esp32-example-jnge-mppt-controller.yaml
@@ -12,6 +12,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-jnge-mppt-controller"

--- a/esp32-example-jnge-wind-solar-controller.yaml
+++ b/esp32-example-jnge-wind-solar-controller.yaml
@@ -9,6 +9,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-jnge-mppt-controller"

--- a/esp32-example-jnge-wind-solar-controller.yaml
+++ b/esp32-example-jnge-wind-solar-controller.yaml
@@ -1,7 +1,7 @@
 substitutions:
   name: jnge-wind-solar-hybrid
-  status: "${name} status"
-  config: "${name} config"
+  status: "status"
+  config: "config"
   device_description: "Monitor and control a JN-W/S Wind and Solar Hybrid Controller via RS485 (Modbus)"
   external_components_source: github://syssi/esphome-jnge-mppt-controller@main
   tx_pin: GPIO16

--- a/esp8266-example-jnge-g-series.yaml
+++ b/esp8266-example-jnge-g-series.yaml
@@ -9,6 +9,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-jnge-mppt-controller"

--- a/esp8266-example-jnge-g-series.yaml
+++ b/esp8266-example-jnge-g-series.yaml
@@ -1,7 +1,7 @@
 substitutions:
   name: jn-g
-  status: "${name} status"
-  config: "${name} config"
+  status: "status"
+  config: "config"
   device_description: "Monitor a JN-G series inverter via RS485 (Modbus)"
   external_components_source: github://syssi/esphome-jnge-mppt-controller@main
   tx_pin: GPIO4

--- a/esp8266-example-jnge-mppt-controller.yaml
+++ b/esp8266-example-jnge-mppt-controller.yaml
@@ -1,7 +1,7 @@
 substitutions:
   name: jn-mppt
-  status: "${name} status"
-  config: "${name} config"
+  status: "status"
+  config: "config"
   device_description: "Monitor and control a JN-MPPT Solar Charge Controller via RS485 (Modbus)"
   external_components_source: github://syssi/esphome-jnge-mppt-controller@main
   tx_pin: GPIO4

--- a/esp8266-example-jnge-mppt-controller.yaml
+++ b/esp8266-example-jnge-mppt-controller.yaml
@@ -9,6 +9,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-jnge-mppt-controller"

--- a/esp8266-example-jnge-wind-solar-controller.yaml
+++ b/esp8266-example-jnge-wind-solar-controller.yaml
@@ -1,7 +1,7 @@
 substitutions:
   name: jnge-wind-solar-hybrid
-  status: "${name} status"
-  config: "${name} config"
+  status: "status"
+  config: "config"
   device_description: "Monitor and control a JN-W/S Wind and Solar Hybrid Controller via RS485 (Modbus)"
   external_components_source: github://syssi/esphome-jnge-mppt-controller@main
   tx_pin: GPIO4

--- a/esp8266-example-jnge-wind-solar-controller.yaml
+++ b/esp8266-example-jnge-wind-solar-controller.yaml
@@ -9,6 +9,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-jnge-mppt-controller"

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
 
 esp32:

--- a/tests/esp8266-fake-g-series.yaml
+++ b/tests/esp8266-fake-g-series.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini


### PR DESCRIPTION
ESPHome's `friendly_name` automatically prefixes all entity names, making the `${name}` substitution in entity name strings redundant.