### PR TITLE
Replace static const char arrays with constexpr

### DIFF
--- a/components/jnge_mppt_controller/jnge_mppt_controller.cpp
+++ b/components/jnge_mppt_controller/jnge_mppt_controller.cpp
@@ -12,7 +12,7 @@ static const uint8_t READ_INPUT_REGISTERS = 0x04;
 static const uint8_t WRITE_SINGLE_REGISTER = 0x06;
 
 static const uint8_t ERRORS_SIZE = 16;
-static const char *const ERRORS[ERRORS_SIZE] = {
+static constexpr const char *const ERRORS[ERRORS_SIZE] = {
     "Battery overpressure",      // Byte 0.0, error
     "Battery is not connected",  // Byte 0.1, error
     "PV array overvoltage",      // Byte 0.2, error
@@ -33,7 +33,7 @@ static const char *const ERRORS[ERRORS_SIZE] = {
 };
 
 static const uint8_t OPERATION_MODES_SIZE = 5;
-static const char *const OPERATION_MODES[OPERATION_MODES_SIZE] = {
+static constexpr const char *const OPERATION_MODES[OPERATION_MODES_SIZE] = {
     "Not charging",       // 0x00
     "MPPT charging",      // 0x01
     "Boost charging",     // 0x02
@@ -42,7 +42,7 @@ static const char *const OPERATION_MODES[OPERATION_MODES_SIZE] = {
 };
 
 static const uint8_t BATTERY_TYPES_SIZE = 5;
-static const char *const BATTERY_TYPES[BATTERY_TYPES_SIZE] = {
+static constexpr const char *const BATTERY_TYPES[BATTERY_TYPES_SIZE] = {
     "Lead Acid",        // 0x00
     "Gel",              // 0x01
     "Ternary Lithium",  // 0x02

--- a/components/jnge_wind_solar_controller/jnge_wind_solar_controller.cpp
+++ b/components/jnge_wind_solar_controller/jnge_wind_solar_controller.cpp
@@ -11,7 +11,7 @@ static const uint8_t READ_REGISTERS = 0x03;
 static const uint8_t WRITE_SINGLE_REGISTER = 0x06;
 
 static const uint8_t ERRORS_SIZE = 16;
-static const char *const ERRORS[ERRORS_SIZE] = {
+static constexpr const char *const ERRORS[ERRORS_SIZE] = {
     "PV charging overcurrent",          // Byte 0.0, error
     "Short circuit fault",              // Byte 0.1, error
     "",                                 // Byte 0.2, error
@@ -33,7 +33,7 @@ static const char *const ERRORS[ERRORS_SIZE] = {
 };
 
 static const uint8_t OPERATION_MODES_SIZE = 5;
-static const char *const OPERATION_MODES[OPERATION_MODES_SIZE] = {
+static constexpr const char *const OPERATION_MODES[OPERATION_MODES_SIZE] = {
     "Not charging",               // 0x00
     "Constant-current charging",  // 0x01
     "Boost charging",             // 0x02
@@ -41,7 +41,7 @@ static const char *const OPERATION_MODES[OPERATION_MODES_SIZE] = {
 };
 
 static const uint8_t BATTERY_TYPES_SIZE = 5;
-static const char *const BATTERY_TYPES[BATTERY_TYPES_SIZE] = {
+static constexpr const char *const BATTERY_TYPES[BATTERY_TYPES_SIZE] = {
     "Unknown",          // 0x00
     "Lead-Acid",        // 0x01
     "LiFePo4",          // 0x02


### PR DESCRIPTION
## Summary

- Replace `static const char *const` with `static constexpr const char *const` for all string array declarations in the affected `.cpp` files
- Affected arrays: `ERRORS`, `OPERATION_MODES`, `BATTERY_TYPES` in both `jnge_mppt_controller.cpp` and `jnge_wind_solar_controller.cpp`

## Details

Using `static constexpr const char *const` for string arrays ensures the data is placed in the read-only segment (Flash) at compile time rather than occupying RAM at runtime. This matches the style used in the ESPHome core (e.g. `bme68x_bsec2.cpp`) and is the preferred approach for embedded targets where RAM is a scarce resource.

Single string pointers like `TAG` are intentionally left unchanged, as they are already `static const char *const` and not arrays.