### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/jnge_g_series/jnge_g_series.cpp
+++ b/components/jnge_g_series/jnge_g_series.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace jnge_g_series {
+namespace esphome::jnge_g_series {
 
 static const char *const TAG = "jnge_g_series";
 
@@ -142,5 +141,4 @@ void JngeGSeries::dump_config() {  // NOLINT(google-readability-function-size,re
   LOG_SENSOR("", "AC Output Power", this->ac_output_power_sensor_);
 }
 
-}  // namespace jnge_g_series
-}  // namespace esphome
+}  // namespace esphome::jnge_g_series

--- a/components/jnge_g_series/jnge_g_series.h
+++ b/components/jnge_g_series/jnge_g_series.h
@@ -4,8 +4,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/jnge_modbus/jnge_modbus.h"
 
-namespace esphome {
-namespace jnge_g_series {
+namespace esphome::jnge_g_series {
 
 static const uint8_t NO_RESPONSE_THRESHOLD = 15;
 
@@ -57,5 +56,4 @@ class JngeGSeries : public PollingComponent, public jnge_modbus::JngeModbusDevic
   void publish_device_offline_();
 };
 
-}  // namespace jnge_g_series
-}  // namespace esphome
+}  // namespace esphome::jnge_g_series

--- a/components/jnge_modbus/jnge_modbus.cpp
+++ b/components/jnge_modbus/jnge_modbus.cpp
@@ -1,8 +1,7 @@
 #include "jnge_modbus.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace jnge_modbus {
+namespace esphome::jnge_modbus {
 
 static const char *const TAG = "jnge_modbus";
 
@@ -137,5 +136,4 @@ void JngeModbus::send(uint8_t address, uint8_t function, uint16_t start_address,
     this->flow_control_pin_->digital_write(false);
 }
 
-}  // namespace jnge_modbus
-}  // namespace esphome
+}  // namespace esphome::jnge_modbus

--- a/components/jnge_modbus/jnge_modbus.h
+++ b/components/jnge_modbus/jnge_modbus.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace jnge_modbus {
+namespace esphome::jnge_modbus {
 
 class JngeModbusDevice;
 
@@ -55,5 +54,4 @@ class JngeModbusDevice {
   uint8_t address_;
 };
 
-}  // namespace jnge_modbus
-}  // namespace esphome
+}  // namespace esphome::jnge_modbus

--- a/components/jnge_mppt_controller/jnge_mppt_controller.cpp
+++ b/components/jnge_mppt_controller/jnge_mppt_controller.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace jnge_mppt_controller {
+namespace esphome::jnge_mppt_controller {
 
 static const char *const TAG = "jnge_mppt_controller";
 
@@ -613,5 +612,4 @@ void JngeMpptController::dump_config() {  // NOLINT(google-readability-function-
   LOG_BINARY_SENSOR("", "Load Detected", this->load_detected_binary_sensor_);
 }
 
-}  // namespace jnge_mppt_controller
-}  // namespace esphome
+}  // namespace esphome::jnge_mppt_controller

--- a/components/jnge_mppt_controller/jnge_mppt_controller.h
+++ b/components/jnge_mppt_controller/jnge_mppt_controller.h
@@ -9,8 +9,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/jnge_modbus/jnge_modbus.h"
 
-namespace esphome {
-namespace jnge_mppt_controller {
+namespace esphome::jnge_mppt_controller {
 
 static const uint8_t NO_RESPONSE_THRESHOLD = 15;
 
@@ -351,5 +350,4 @@ class JngeMpptController : public PollingComponent, public jnge_modbus::JngeModb
   std::string error_bits_to_string_(uint16_t bitmask);
 };
 
-}  // namespace jnge_mppt_controller
-}  // namespace esphome
+}  // namespace esphome::jnge_mppt_controller

--- a/components/jnge_mppt_controller/number/jnge_number.cpp
+++ b/components/jnge_mppt_controller/number/jnge_number.cpp
@@ -1,8 +1,7 @@
 #include "jnge_number.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace jnge_mppt_controller {
+namespace esphome::jnge_mppt_controller {
 
 static const char *const TAG = "jnge_mppt_controller.number";
 
@@ -11,5 +10,4 @@ void JngeNumber::control(float value) {
 }
 void JngeNumber::dump_config() { LOG_NUMBER(TAG, "JngeMpptController Number", this); }
 
-}  // namespace jnge_mppt_controller
-}  // namespace esphome
+}  // namespace esphome::jnge_mppt_controller

--- a/components/jnge_mppt_controller/number/jnge_number.h
+++ b/components/jnge_mppt_controller/number/jnge_number.h
@@ -5,8 +5,7 @@
 #include "esphome/components/number/number.h"
 #include "esphome/core/preferences.h"
 
-namespace esphome {
-namespace jnge_mppt_controller {
+namespace esphome::jnge_mppt_controller {
 
 class JngeMpptController;
 
@@ -23,5 +22,4 @@ class JngeNumber : public number::Number, public Component {
   uint16_t holding_register_;
 };
 
-}  // namespace jnge_mppt_controller
-}  // namespace esphome
+}  // namespace esphome::jnge_mppt_controller

--- a/components/jnge_mppt_controller/select/jnge_select.cpp
+++ b/components/jnge_mppt_controller/select/jnge_select.cpp
@@ -1,8 +1,7 @@
 #include "jnge_select.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace jnge_mppt_controller {
+namespace esphome::jnge_mppt_controller {
 
 static const char *const TAG = "jnge_mppt_controller.select";
 
@@ -43,5 +42,4 @@ void JngeSelect::control(const std::string &value) {
   ESP_LOGW(TAG, "Invalid value %s", value.c_str());
 }
 
-}  // namespace jnge_mppt_controller
-}  // namespace esphome
+}  // namespace esphome::jnge_mppt_controller

--- a/components/jnge_mppt_controller/select/jnge_select.h
+++ b/components/jnge_mppt_controller/select/jnge_select.h
@@ -7,8 +7,7 @@
 #include "esphome/components/select/select.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace jnge_mppt_controller {
+namespace esphome::jnge_mppt_controller {
 
 class JngeMpptController;
 
@@ -29,5 +28,4 @@ class JngeSelect : public Component, public select::Select {
   uint16_t holding_register_;
 };
 
-}  // namespace jnge_mppt_controller
-}  // namespace esphome
+}  // namespace esphome::jnge_mppt_controller

--- a/components/jnge_mppt_controller/switch/jnge_switch.cpp
+++ b/components/jnge_mppt_controller/switch/jnge_switch.cpp
@@ -2,13 +2,11 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace jnge_mppt_controller {
+namespace esphome::jnge_mppt_controller {
 
 static const char *const TAG = "jnge_mppt_controller.switch";
 
 void JngeSwitch::dump_config() { LOG_SWITCH("", "JngeMpptController Switch", this); }
 void JngeSwitch::write_state(bool state) { this->parent_->write_register(this->holding_register_, (uint16_t) state); }
 
-}  // namespace jnge_mppt_controller
-}  // namespace esphome
+}  // namespace esphome::jnge_mppt_controller

--- a/components/jnge_mppt_controller/switch/jnge_switch.h
+++ b/components/jnge_mppt_controller/switch/jnge_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace jnge_mppt_controller {
+namespace esphome::jnge_mppt_controller {
 
 class JngeMpptController;
 
@@ -23,5 +22,4 @@ class JngeSwitch : public switch_::Switch, public Component {
   uint16_t holding_register_;
 };
 
-}  // namespace jnge_mppt_controller
-}  // namespace esphome
+}  // namespace esphome::jnge_mppt_controller

--- a/components/jnge_wind_solar_controller/jnge_wind_solar_controller.cpp
+++ b/components/jnge_wind_solar_controller/jnge_wind_solar_controller.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace jnge_wind_solar_controller {
+namespace esphome::jnge_wind_solar_controller {
 
 static const char *const TAG = "jnge_wind_solar_controller";
 
@@ -303,5 +302,4 @@ void JngeWindSolarController::dump_config() {  // NOLINT(google-readability-func
   LOG_TEXT_SENSOR("", "Errors", this->errors_text_sensor_);
 }
 
-}  // namespace jnge_wind_solar_controller
-}  // namespace esphome
+}  // namespace esphome::jnge_wind_solar_controller

--- a/components/jnge_wind_solar_controller/jnge_wind_solar_controller.h
+++ b/components/jnge_wind_solar_controller/jnge_wind_solar_controller.h
@@ -7,8 +7,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/jnge_modbus/jnge_modbus.h"
 
-namespace esphome {
-namespace jnge_wind_solar_controller {
+namespace esphome::jnge_wind_solar_controller {
 
 static const uint8_t NO_RESPONSE_THRESHOLD = 15;
 
@@ -136,5 +135,4 @@ class JngeWindSolarController : public PollingComponent, public jnge_modbus::Jng
   std::string error_bits_to_string_(uint16_t bitmask);
 };
 
-}  // namespace jnge_wind_solar_controller
-}  // namespace esphome
+}  // namespace esphome::jnge_wind_solar_controller

--- a/components/jnge_wind_solar_controller/switch/jnge_switch.cpp
+++ b/components/jnge_wind_solar_controller/switch/jnge_switch.cpp
@@ -2,13 +2,11 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace jnge_wind_solar_controller {
+namespace esphome::jnge_wind_solar_controller {
 
 static const char *const TAG = "jnge_wind_solar_controller.switch";
 
 void JngeSwitch::dump_config() { LOG_SWITCH("", "JngeWindSolarController Switch", this); }
 void JngeSwitch::write_state(bool state) { this->parent_->write_register(this->holding_register_, (uint16_t) state); }
 
-}  // namespace jnge_wind_solar_controller
-}  // namespace esphome
+}  // namespace esphome::jnge_wind_solar_controller

--- a/components/jnge_wind_solar_controller/switch/jnge_switch.h
+++ b/components/jnge_wind_solar_controller/switch/jnge_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace jnge_wind_solar_controller {
+namespace esphome::jnge_wind_solar_controller {
 
 class JngeWindSolarController;
 class JngeSwitch : public switch_::Switch, public Component {
@@ -22,5 +21,4 @@ class JngeSwitch : public switch_::Switch, public Component {
   uint16_t holding_register_;
 };
 
-}  // namespace jnge_wind_solar_controller
-}  // namespace esphome
+}  // namespace esphome::jnge_wind_solar_controller


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.