### PR TITLE
Add C++ tests for jnge_modbus

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -551,7 +551,7 @@ jobs:
       - name: Run C++ unit tests
         run: |
           . venv/bin/activate
-          script/cpp_unit_test.py jnge_g_series jnge_mppt_controller jnge_wind_solar_controller
+          script/cpp_unit_test.py jnge_g_series jnge_modbus jnge_mppt_controller jnge_wind_solar_controller
         env:
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
           ASAN_OPTIONS: detect_leaks=0

--- a/tests/components/jnge_modbus/common.h
+++ b/tests/components/jnge_modbus/common.h
@@ -1,0 +1,49 @@
+#pragma once
+#include <cstdint>
+#include <vector>
+#include "esphome/components/jnge_modbus/jnge_modbus.h"
+
+namespace esphome::jnge_modbus::testing {
+
+class MockJngeModbusDevice : public JngeModbusDevice {
+ public:
+  uint8_t last_function{0xFF};
+  std::vector<uint8_t> received_data;
+  int call_count{0};
+
+  void on_jnge_modbus_data(const uint8_t &function, const std::vector<uint8_t> &data) override {
+    last_function = function;
+    received_data = data;
+    call_count++;
+  }
+};
+
+class TestableJngeModbus : public JngeModbus {
+ public:
+  void loop() override {}
+  using JngeModbus::parse_jnge_modbus_byte_;
+
+  bool feed(const std::vector<uint8_t> &frame) {
+    bool result = false;
+    for (uint8_t byte : frame)
+      result = parse_jnge_modbus_byte_(byte);
+    return result;
+  }
+};
+
+// Build a valid response frame with CRC.
+// Format: [addr, func, data_len, data..., crc_lo, crc_hi]
+inline std::vector<uint8_t> make_response_frame(uint8_t address, uint8_t function,
+                                                 const std::vector<uint8_t> &data) {
+  std::vector<uint8_t> frame;
+  frame.push_back(address);
+  frame.push_back(function);
+  frame.push_back(static_cast<uint8_t>(data.size()));
+  frame.insert(frame.end(), data.begin(), data.end());
+  uint16_t crc = crc16(frame.data(), static_cast<uint8_t>(frame.size()));
+  frame.push_back(static_cast<uint8_t>(crc & 0xFF));
+  frame.push_back(static_cast<uint8_t>(crc >> 8));
+  return frame;
+}
+
+}  // namespace esphome::jnge_modbus::testing

--- a/tests/components/jnge_modbus/common.h
+++ b/tests/components/jnge_modbus/common.h
@@ -25,8 +25,11 @@ class TestableJngeModbus : public JngeModbus {
 
   bool feed(const std::vector<uint8_t> &frame) {
     bool result = false;
-    for (uint8_t byte : frame)
+    for (uint8_t byte : frame) {
       result = parse_jnge_modbus_byte_(byte);
+      if (!result)
+        rx_buffer_.clear();
+    }
     return result;
   }
 };

--- a/tests/components/jnge_modbus/common.h
+++ b/tests/components/jnge_modbus/common.h
@@ -33,8 +33,7 @@ class TestableJngeModbus : public JngeModbus {
 
 // Build a valid response frame with CRC.
 // Format: [addr, func, data_len, data..., crc_lo, crc_hi]
-inline std::vector<uint8_t> make_response_frame(uint8_t address, uint8_t function,
-                                                 const std::vector<uint8_t> &data) {
+inline std::vector<uint8_t> make_response_frame(uint8_t address, uint8_t function, const std::vector<uint8_t> &data) {
   std::vector<uint8_t> frame;
   frame.push_back(address);
   frame.push_back(function);

--- a/tests/components/jnge_modbus/jnge_modbus_test.cpp
+++ b/tests/components/jnge_modbus/jnge_modbus_test.cpp
@@ -1,0 +1,134 @@
+#include <gtest/gtest.h>
+#include "common.h"
+
+namespace esphome::jnge_modbus::testing {
+
+// crc16 (CRC-16/MODBUS)
+
+TEST(Crc16Test, ZeroLengthIsAllOnes) {
+  // CRC of empty data starts at 0xFFFF but no XOR is done -> 0xFFFF
+  EXPECT_EQ(crc16(nullptr, 0), 0xFFFF);
+}
+
+TEST(Crc16Test, SingleByte) {
+  // crc16({0x01}) should match CRC-16/MODBUS standard
+  uint8_t data[] = {0x01};
+  uint16_t crc = crc16(data, 1);
+  // Verify self-consistency: crc of (data + crc_lo + crc_hi) == 0
+  uint8_t extended[] = {0x01, static_cast<uint8_t>(crc & 0xFF), static_cast<uint8_t>(crc >> 8)};
+  EXPECT_EQ(crc16(extended, 3), 0x0000);
+}
+
+TEST(Crc16Test, FrameCrcSelfCheck) {
+  // A correctly framed message has CRC-16 of 0x0000 when the CRC bytes are appended.
+  std::vector<uint8_t> data = {0xAB, 0xCD, 0xEF};
+  uint16_t crc = crc16(data.data(), static_cast<uint8_t>(data.size()));
+  data.push_back(static_cast<uint8_t>(crc & 0xFF));
+  data.push_back(static_cast<uint8_t>(crc >> 8));
+  EXPECT_EQ(crc16(data.data(), static_cast<uint8_t>(data.size())), 0x0000);
+}
+
+// Frame parsing and device dispatch
+
+TEST(JngeModbusParseTest, ValidFrameDispatchedToDevice) {
+  TestableJngeModbus modbus;
+  MockJngeModbusDevice device;
+  device.set_address(0x01);
+  modbus.register_device(&device);
+
+  auto frame = make_response_frame(0x01, 0x03, {0xAB, 0xCD});
+  modbus.feed(frame);
+
+  EXPECT_EQ(device.call_count, 1);
+  EXPECT_EQ(device.last_function, 0x03);
+  ASSERT_EQ(device.received_data.size(), 2u);
+  EXPECT_EQ(device.received_data[0], 0xAB);
+  EXPECT_EQ(device.received_data[1], 0xCD);
+}
+
+TEST(JngeModbusParseTest, Function04Dispatched) {
+  TestableJngeModbus modbus;
+  MockJngeModbusDevice device;
+  device.set_address(0x02);
+  modbus.register_device(&device);
+
+  auto frame = make_response_frame(0x02, 0x04, {0x00, 0x78, 0x00, 0x00});
+  modbus.feed(frame);
+
+  EXPECT_EQ(device.call_count, 1);
+  EXPECT_EQ(device.last_function, 0x04);
+  EXPECT_EQ(device.received_data.size(), 4u);
+}
+
+TEST(JngeModbusParseTest, TwoFramesDispatchedTwice) {
+  TestableJngeModbus modbus;
+  MockJngeModbusDevice device;
+  device.set_address(0x01);
+  modbus.register_device(&device);
+
+  auto frame = make_response_frame(0x01, 0x03, {0x11, 0x22});
+  modbus.feed(frame);
+  modbus.feed(frame);
+
+  EXPECT_EQ(device.call_count, 2);
+}
+
+TEST(JngeModbusParseTest, ErrorFunctionRejected) {
+  TestableJngeModbus modbus;
+  MockJngeModbusDevice device;
+  device.set_address(0x01);
+  modbus.register_device(&device);
+
+  // Bit 7 set in function byte -> error frame, rejected at byte 1
+  bool result = modbus.parse_jnge_modbus_byte_(0x01);  // address
+  EXPECT_TRUE(result);
+  result = modbus.parse_jnge_modbus_byte_(0x83);  // function with error bit
+  EXPECT_FALSE(result);
+  EXPECT_EQ(device.call_count, 0);
+}
+
+TEST(JngeModbusParseTest, BadCrcRejected) {
+  TestableJngeModbus modbus;
+  MockJngeModbusDevice device;
+  device.set_address(0x01);
+  modbus.register_device(&device);
+
+  auto frame = make_response_frame(0x01, 0x03, {0xAB, 0xCD});
+  frame.back() ^= 0xFF;  // corrupt CRC high byte
+  modbus.feed(frame);
+
+  EXPECT_EQ(device.call_count, 0);
+}
+
+TEST(JngeModbusParseTest, UnknownAddressNotDispatched) {
+  TestableJngeModbus modbus;
+  MockJngeModbusDevice device;
+  device.set_address(0x99);
+  modbus.register_device(&device);
+
+  auto frame = make_response_frame(0x01, 0x03, {0xAB, 0xCD});
+  modbus.feed(frame);
+
+  EXPECT_EQ(device.call_count, 0);
+}
+
+TEST(JngeModbusParseTest, NoRegisteredDeviceDoesNotCrash) {
+  TestableJngeModbus modbus;
+  auto frame = make_response_frame(0x01, 0x03, {0xAB, 0xCD});
+  modbus.feed(frame);
+}
+
+TEST(JngeModbusParseTest, PartialFrameDoesNotDispatch) {
+  TestableJngeModbus modbus;
+  MockJngeModbusDevice device;
+  device.set_address(0x01);
+  modbus.register_device(&device);
+
+  auto frame = make_response_frame(0x01, 0x03, {0xAB, 0xCD, 0xEF, 0x12});
+  for (size_t i = 0; i < frame.size() - 2; i++)
+    modbus.parse_jnge_modbus_byte_(frame[i]);
+
+  EXPECT_EQ(device.call_count, 0);
+}
+
+}  // namespace esphome::jnge_modbus::testing

--- a/tests/components/jnge_modbus/test.host.yaml
+++ b/tests/components/jnge_modbus/test.host.yaml
@@ -1,0 +1,7 @@
+uart:
+  - id: uart_bus
+    baud_rate: 9600
+
+jnge_modbus:
+  - id: modbus_bus
+    uart_id: uart_bus


### PR DESCRIPTION
## Summary

Add `tests/components/jnge_modbus/` with 11 unit tests for the modbus transport layer.

## Coverage

- `crc16`: zero-length input, single-byte self-check, multi-byte self-check (appending CRC bytes gives 0x0000)
- Frame parsing: valid frame dispatched with correct function code and data, function 0x03 and 0x04, two consecutive frames, error bit (bit 7 in function byte) rejected at byte 1, bad CRC rejected, unknown address not dispatched, no registered device (no crash), partial frame (missing CRC bytes) no dispatch

## Test plan

- [ ] `esphome compile tests/components/jnge_modbus/test.host.yaml`
- [ ] Run gtest binary from host build