### PR TITLE
Replace locally defined unit constants with esphome.const imports

### DIFF
--- a/components/jnge_g_series/__init__.py
+++ b/components/jnge_g_series/__init__.py
@@ -13,8 +13,6 @@ MULTI_CONF = True
 
 CONF_JNGE_G_SERIES_ID = "jnge_g_series_id"
 
-UNIT_HOURS = "h"
-
 jnge_g_series_ns = cg.esphome_ns.namespace("jnge_g_series")
 JngeGSeries = jnge_g_series_ns.class_(
     "JngeGSeries", cg.PollingComponent, jnge_modbus.JngeModbusDevice

--- a/components/jnge_mppt_controller/__init__.py
+++ b/components/jnge_mppt_controller/__init__.py
@@ -20,8 +20,6 @@ CONF_JNGE_MPPT_CONTROLLER_ID = "jnge_mppt_controller_id"
 CONF_ENABLE_FAKE_TRAFFIC = "enable_fake_traffic"
 CONF_SUPPRESS_BATTERY_TEMPERATURE_ERRORS = "suppress_battery_temperature_errors"
 
-UNIT_HOURS = "h"
-
 jnge_mppt_controller_ns = cg.esphome_ns.namespace("jnge_mppt_controller")
 JngeMpptController = jnge_mppt_controller_ns.class_(
     "JngeMpptController", cg.PollingComponent, jnge_modbus.JngeModbusDevice

--- a/components/jnge_mppt_controller/number/__init__.py
+++ b/components/jnge_mppt_controller/number/__init__.py
@@ -10,13 +10,13 @@ from esphome.const import (
     ENTITY_CATEGORY_CONFIG,
     ICON_EMPTY,
     UNIT_EMPTY,
+    UNIT_HOUR,
     UNIT_VOLT,
 )
 
 from .. import (
     CONF_JNGE_MPPT_CONTROLLER_ID,
     JNGE_MPPT_CONTROLLER_COMPONENT_SCHEMA,
-    UNIT_HOURS,
     jnge_mppt_controller_ns,
 )
 
@@ -154,7 +154,7 @@ CONFIG_SCHEMA = JNGE_MPPT_CONTROLLER_COMPONENT_SCHEMA.extend(
                 cv.Optional(CONF_MAX_VALUE, default=3): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.float_,
                 cv.Optional(
-                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_HOURS
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_HOUR
                 ): cv.string_strict,
             }
         ),
@@ -164,7 +164,7 @@ CONFIG_SCHEMA = JNGE_MPPT_CONTROLLER_COMPONENT_SCHEMA.extend(
                 cv.Optional(CONF_MAX_VALUE, default=3): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.float_,
                 cv.Optional(
-                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_HOURS
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_HOUR
                 ): cv.string_strict,
             }
         ),
@@ -188,7 +188,7 @@ CONFIG_SCHEMA = JNGE_MPPT_CONTROLLER_COMPONENT_SCHEMA.extend(
                 cv.Optional(CONF_MAX_VALUE, default=24): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.float_,
                 cv.Optional(
-                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_HOURS
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_HOUR
                 ): cv.string_strict,
             }
         ),
@@ -198,7 +198,7 @@ CONFIG_SCHEMA = JNGE_MPPT_CONTROLLER_COMPONENT_SCHEMA.extend(
                 cv.Optional(CONF_MAX_VALUE, default=24): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.float_,
                 cv.Optional(
-                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_HOURS
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_HOUR
                 ): cv.string_strict,
             }
         ),
@@ -208,7 +208,7 @@ CONFIG_SCHEMA = JNGE_MPPT_CONTROLLER_COMPONENT_SCHEMA.extend(
                 cv.Optional(CONF_MAX_VALUE, default=24): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.float_,
                 cv.Optional(
-                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_HOURS
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_HOUR
                 ): cv.string_strict,
             }
         ),

--- a/components/jnge_mppt_controller/sensor.py
+++ b/components/jnge_mppt_controller/sensor.py
@@ -20,17 +20,15 @@ from esphome.const import (
     UNIT_AMPERE,
     UNIT_CELSIUS,
     UNIT_EMPTY,
+    UNIT_HOUR,
     UNIT_KILOWATT_HOURS,
+    UNIT_MILLIVOLT,
     UNIT_PERCENT,
     UNIT_VOLT,
     UNIT_WATT,
 )
 
-from . import (
-    CONF_JNGE_MPPT_CONTROLLER_ID,
-    JNGE_MPPT_CONTROLLER_COMPONENT_SCHEMA,
-    UNIT_HOURS,
-)
+from . import CONF_JNGE_MPPT_CONTROLLER_ID, JNGE_MPPT_CONTROLLER_COMPONENT_SCHEMA
 
 DEPENDENCIES = ["jnge_mppt_controller"]
 
@@ -87,7 +85,6 @@ ICON_TEMPERATURE_COMPENSATION_COEFFICIENT = "mdi:thermometer-plus"
 ICON_OPERATION_MODE = "mdi:heart-pulse"
 ICON_DISCHARGE_TIMES = "mdi:counter"
 
-UNIT_MILLIVOLT = "mV"
 UNIT_MILLIVOLT_PER_CELSIUS = "mV/°C"
 
 SENSOR_DEFS = {
@@ -331,14 +328,14 @@ SENSOR_DEFS = {
         "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_EQUALIZATION_CHARGING_TIME: {
-        "unit_of_measurement": UNIT_HOURS,
+        "unit_of_measurement": UNIT_HOUR,
         "icon": ICON_TIMELAPSE,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_IMPROVE_CHARGING_TIME: {
-        "unit_of_measurement": UNIT_HOURS,
+        "unit_of_measurement": UNIT_HOUR,
         "icon": ICON_TIMELAPSE,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
@@ -373,21 +370,21 @@ SENSOR_DEFS = {
         "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_LIGHT_CONTROL_ON_PERIOD_1: {
-        "unit_of_measurement": UNIT_HOURS,
+        "unit_of_measurement": UNIT_HOUR,
         "icon": ICON_TIMER,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_LIGHT_CONTROL_ON_PERIOD_2: {
-        "unit_of_measurement": UNIT_HOURS,
+        "unit_of_measurement": UNIT_HOUR,
         "icon": ICON_TIMER,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_LOAD_TURN_OFF_TIME: {
-        "unit_of_measurement": UNIT_HOURS,
+        "unit_of_measurement": UNIT_HOUR,
         "icon": ICON_TIMER,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,

--- a/components/jnge_wind_solar_controller/sensor.py
+++ b/components/jnge_wind_solar_controller/sensor.py
@@ -50,8 +50,6 @@ ICON_TEMPERATURE_COMPENSATION_COEFFICIENT = "mdi:thermometer-plus"
 ICON_OPERATION_MODE = "mdi:heart-pulse"
 ICON_DISCHARGE_TIMES = "mdi:counter"
 
-UNIT_HOURS = "h"
-UNIT_MILLIVOLT = "mV"
 UNIT_MILLIVOLT_PER_CELSIUS = "mV/°C"
 
 # key: sensor_schema kwargs


### PR DESCRIPTION
## Summary

Several components defined their own unit constants that are already available in `esphome.const`. This imports the canonical names and removes the local duplicates (including some that were unused).

| Local definition | Replaced by |
|---|---|
| `UNIT_HOURS = "h"` | `UNIT_HOUR` |
| `UNIT_MILLIVOLT = "mV"` | `UNIT_MILLIVOLT` |

`jnge_mppt_controller` defined `UNIT_HOURS` at package level and re-imported it into the `sensor` and `number` platforms; these now import `UNIT_HOUR` directly from `esphome.const`. The unused local definitions in `jnge_g_series` and `jnge_wind_solar_controller` are dropped.

**Affected files:** `jnge_mppt_controller/__init__`, `jnge_mppt_controller/sensor`, `jnge_mppt_controller/number`, `jnge_g_series/__init__`, `jnge_wind_solar_controller/sensor`

No functional change — the string values are identical.